### PR TITLE
changed media filename format

### DIFF
--- a/studip_sync/session.py
+++ b/studip_sync/session.py
@@ -184,13 +184,13 @@ class Session(object):
             media_player_url_relative = media_file[1]
             media_player_url = requests.compat.urljoin(mediacast_list_url, media_player_url_relative)
 
-            # files are saved as "{hash}-{filename}"
+            # files are saved as "{filename}-{hash}.{file extension}"
 
             found_existing_file = False
 
             for workdir_filename in workdir_files:
                 workdir_filename_split = workdir_filename.split("-")
-                if len(workdir_filename_split) > 0 and workdir_filename_split[0] == media_hash:
+                if len(workdir_filename_split) > 0 and ( workdir_filename_split[-1].split(".")[0] == media_hash or workdir_filename_split[0] == media_hash):
                     found_existing_file = True
                     break
 
@@ -214,9 +214,17 @@ class Session(object):
                     print("\t\tCannot download media file: " + str(response))
                     continue
 
-                media_filename = parsers.extract_filename_from_headers(response.headers)
+                media_full_filename = parsers.extract_filename_from_headers(response.headers).split(".")
 
-                filename = media_hash + "-" + media_filename
+                media_file_extension = media_full_filename.pop(-1)
+
+                # reintroduce missing '.' in the middle of the filename
+                for part in media_full_filename[:-1] :
+                    part = part + "."
+
+                media_filename = "".join(media_full_filename)
+
+                filename = media_filename + "-" + media_hash + "." + media_file_extension
 
                 filepath = os.path.join(media_workdir, filename)
 


### PR DESCRIPTION
The filename format was changed from ```{hash}-{filename}``` to ```{filename}-{hash}-{file extension}``` to make use of the lexicographical ordering of the downloaded media.

**previous problem**: multiple downloaded media files form the same lecture would (when shown in lexicographical ordering) not be presented next to each other because of the leading and differing hashes in the filename.

**situation now**: if a file lies on the server as ```file.extension```, then it is saved as ```file-{hash}.extension```. This enables files (example: `````lecture01-part1.mp4, lecture01-part2.mp4, lecture01-part3.mp4`````) to actually be shown in that order, no matter what the hashes of the files turn out to be.

The changes should respect the old format and shouldn't re-download existing files that are saved in the old format.